### PR TITLE
Fix for 0.8.x

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -208,7 +208,7 @@ class PathfindingRuler
 		}
 		let ray = new Ray(A,B);
 		if (ray)
-			return WallsLayer.getRayCollisions(ray,{blockMovement:true, blockSenses:false, mode:"any"});
+			return canvas.walls.checkCollision(ray,{blockMovement:true, blockSenses:false, mode:"any"});
 		else return true;
 	}
 	


### PR DESCRIPTION
Fix for the new collision check present in 0.8.x API.

Tested on Foundry VTT (0.8.7) with:
- D&D 5e system (1.3.5);
- Simple World-Building (0.5.0);

Should be good for #4 