### PR TITLE
Feature/libruler compatibility

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -167,9 +167,9 @@ class PathfindingRuler
 	    // otherwise keep the waypoint; do nothing
 	  });
 	  this.ruler._state = Ruler.STATES.MEASURING; // does this accomplish anything now?
-	  this.ruler.destination = new PIXI.Point(endpoint.x,endpoint.y);
+	  //this.ruler.destination = new PIXI.Point(endpoint.x,endpoint.y);
 	  	  
-	  this.ruler.measure(destination);
+	  this.ruler.measure(new PIXI.Point(endpoint.x,endpoint.y));
 	}
 	
  /*
@@ -180,7 +180,7 @@ class PathfindingRuler
   * @return {Boolean} True if the points are within the error of each other 
   */
 	pointsAlmostEqual(p1, p2, EPSILON = 1e-5) {
-	  return this.almostEqual(p1.x, p2.x, EPSILON) && almostEqual(p1.y, p2.y, EPSILON);
+	  return this.almostEqual(p1.x, p2.x, EPSILON) && this.almostEqual(p1.y, p2.y, EPSILON);
 	}
 	
  /*
@@ -289,7 +289,7 @@ class PathfindingRuler
 			}
 			if (currentNode.x=== endpoint.x && currentNode.y === endpoint.y)
 			{
-				this.removeRuler(); // is this removal necessary?
+				//this.removeRuler(); // is this removal necessary?
 				let current = currentNode;
 				let ret = [];
 				while(current.parent)
@@ -342,7 +342,7 @@ class PathfindingRuler
 				}
 			}
 		}
-		this.removeRuler();
+		//this.removeRuler();
 	}
 	
 	isInList(list, node)

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -148,13 +148,15 @@ class PathfindingRuler
 	  // - allow other modules like Elevation Ruler to know when waypoints are added/removed
 	  const endpoint = this.convertGridspaceToLocation(this.endpoint);
 	  
-	  // for each waypoint from origin:
+	  console.log("Pathfinding|drawing", this.waypoints, this.ruler.waypoints);
+          // for each waypoint from origin:
 	  // if same point, keep
 	  // if new point, remove all subsequent waypoints
 	  this.waypoints.forEach((w, idx) => {
-	    if(this.ruler.waypoints.length < idx) {
+            console.log(`Pathfinding| idx ${idx}, w ${w.x}, ${w.y}`, w);
+	    if(this.ruler.waypoints.length <= idx) {
 	      this.ruler._addWaypoint(w);
-	    } else if(!pointsAlmostEqual(this.ruler.waypoints[idx], w)) {
+	    } else if(!this.pointsAlmostEqual(this.ruler.waypoints[idx], w)) {
 	      // remove all waypoints from idx on; then add the new waypoint
 	      const num_to_remove = this.ruler.waypoints.length - idx;
 	      for(let i=0; i < num_to_remove; i++) {

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -113,7 +113,7 @@ class PathfindingRuler
 					if (!this.hitsWall(this.origin,this.endpoint,true))
 					{
 						this.waypoints = [new PIXI.Point(origin.x,origin.y)];
-						this.removeRuler();
+						//this.removeRuler(); duplicative with this.drawRuler now
 						this.drawRuler();
 					}
 					else
@@ -143,17 +143,16 @@ class PathfindingRuler
 	
 	drawRuler()
 	{
-		let newruler = this.ruler;
-		let endpoint = this.convertGridspaceToLocation(this.endpoint);
-		newruler._state = 2;
-		newruler.waypoints = this.waypoints.splice(0);
-		newruler.destination = new PIXI.Point(endpoint.x,endpoint.y);
-		while ( newruler.waypoints.length > newruler.labels.children.length) 
-		{
-			newruler.labels.addChild(new PreciseText("", CONFIG.canvasTextStyle));
-		}
-		newruler.class = "Ruler";
-		this.ruler.update(newruler.toJSON());
+	  const endpoint = this.convertGridspaceToLocation(this.endpoint);
+	  
+	  this.removeRuler();
+	  this.waypoints.forEach(w => {
+	    this.ruler._addWaypoint(w);
+	  });
+	  this.ruler._state = Ruler.STATES.MEASURING; // does this accomplish anything now?
+	  this.ruler.destination = new PIXI.Point(endpoint.x,endpoint.y);
+	  	  
+	  this.ruler.measure(destination);
 	}
 	
 	removeRuler()


### PR DESCRIPTION
Hi! My players really like your Pathfinding ruler! Thanks for setting it up. 

This pull request would allow Pathfinding ruler to play nicely with my [elevation ruler module](https://github.com/caewok/fvtt-elevation-ruler). Essentially, Elevation Ruler (1) takes into account elevation from [Enhanced Terrain Layer](https://github.com/ironmonk88/enhanced-terrain-layer), [Levels](https://github.com/theripper93/Levels), and other tokens; and (2) allows the user to change the destination elevation. The elevations are displayed in the ruler, and distance calculations are modified to consider the 3-D distance movement. 

To make Pathfinding work with Elevation Ruler, I needed to change Pathfinding to use the `_addWaypoint` and `_removeWaypoint` Ruler methods. This is because Elevation Ruler is using those methods to calculate elevation at waypoints. You will see that I did this by keeping your separate set of waypoints, and adding or removing waypoints from the main ruler using those methods. So if there are 6 waypoints, and the first 3 waypoints are the same, my proposed implementation removes the last 3 and re-adds the new ones using `_addWaypoint` and `_removeWaypoint`. If the first and the 6th waypoint are the same, it would remove the last 5 and then re-adds the new ones. (Ruler doesn't really support inserting/modifying waypoints, thus the one-way add/remove.)

I also needed Pathfinding to avoid clearing the Ruler unless strictly necessary. That is because (1) it is a bit resource-intensive to re-create the entire ruler and (2) it confuses modules like Elevation Ruler that expect certain measurements, like the user-elevation setting, to be preserved for a given ruler measurement. So you will see several places where I struck code clearing the ruler. I believe my change to using the waypoints allow this without harming functionality. 

My proposed changes do not, as far as I can tell, change the operation of Pathfinding if Elevation Ruler is not present. It looks to me like the functionality is preserved. And users don't need to do anything other than install Elevation Ruler to use its features in the Pathfinding ruler, so that is a nice bonus. 

This may also help if you decide to tackle #6. FYI, the Drag Ruler creator helped me develop my [libRuler module](https://github.com/caewok/fvtt-lib-ruler), and that may eventually be a means to address #6.

Thanks for considering this! Feel free to reach out with questions. You can find me on discord at caewok#9192. 