### PR TITLE
Libruler compatibility

### DIFF
--- a/module.json
+++ b/module.json
@@ -13,7 +13,7 @@
       "path": "lang/en.json"
     }
   ],
-  "scripts": ["./scripts/main.js"],
+  "esmodules": ["./scripts/main.js"],
   "version": "0.7",
   "minimumCoreVersion": "0.8.7",
   "compatibleCoreVersion": "0.8.7"

--- a/scripts/libruler.js
+++ b/scripts/libruler.js
@@ -32,8 +32,10 @@ Hooks.once('libRulerReady', async function() {
  * @param {boolean} gridSpaces      Restrict measurement only to grid spaces
  */
 function pathfinderMeasure(wrapped, destination, options) {
-  if(game.activeTool === "pathfinding-ruler") {
+  const token_controls = ui.controls.controls.find(elem => elem.name === "token");
+  const pathfinding_control = token_controls.find(elem => elem.name === "pathfinding-ruler");
   
+  if(pathfinding_control.active) {
     // this part adapted from main.js mousemoveListener
     const previous_endpoint = this.getFlag(MODULE_ID, "endpoint");
     const newlocation = PathfindingRuler.convertLocationToGridspace(destination);

--- a/scripts/libruler.js
+++ b/scripts/libruler.js
@@ -12,17 +12,26 @@ import { PathfindingRuler, findPath } from "./main.js";
 
 const MODULE_ID = "pathfinding-ruler"
 
+function log(...args) {
+  try {
+      console.log(MODULE_ID, '|', ...args);
+  } catch (e) {}
+}
 
-
+/*
 Hooks.once('libRulerReady', async function() {
+  log(`libRuler is ready; adding findPath`);
   Object.defineProperty(Ruler.prototype, "findPath", {
     value: findPath,
     writable: true,
     configurable: true
   });
   
+  log(`registering Ruler.measure`);
   libWrapper.register(MODULE_ID, 'Ruler.prototype.measure', pathfinderMeasure, 'WRAPPER');
-}
+  log(`done registration!`);
+};
+*/
 
 // wrap measure -- whenever measure is called, update the waypoints
 // easier than tracking onMouseMove and should result in less unnecessary processing
@@ -31,11 +40,12 @@ Hooks.once('libRulerReady', async function() {
  * @param {PIXI.Point} destination  The destination point to which to measure
  * @param {boolean} gridSpaces      Restrict measurement only to grid spaces
  */
-function pathfinderMeasure(wrapped, destination, options) {
+export function pathfinderMeasure(wrapped, destination, options) {
   const token_controls = ui.controls.controls.find(elem => elem.name === "token");
-  const pathfinding_control = token_controls.find(elem => elem.name === "pathfinding-ruler");
+  const pathfinding_control = token_controls.tools.find(elem => elem.name === "pathfinding-ruler");
   
-  if(pathfinding_control.active) {
+  if(pathfinding_control?.active) {
+    log(`measure: pathfinding control is active. Using `);
     // this part adapted from main.js mousemoveListener
     const previous_endpoint = this.getFlag(MODULE_ID, "endpoint");
     const newlocation = PathfindingRuler.convertLocationToGridspace(destination);
@@ -43,7 +53,7 @@ function pathfinderMeasure(wrapped, destination, options) {
       // we have moved destination to another gridspace. 
       this.setFlag(MODULE_ID, "endpoint", newlocation);
     
-      const origin_grid = PathfindingRuler.convertLocationToGridSpace(this.origin);
+      const origin_grid = PathfindingRuler.convertLocationToGridspace(this.waypoints[0]);
       if(PathfindingRuler.hitsWall(origin_grid, newlocation, true)) {
         this.findPath(origin_grid, newlocation);
       }

--- a/scripts/libruler.js
+++ b/scripts/libruler.js
@@ -8,35 +8,12 @@ See https://github.com/caewok/foundryvtt-drag-ruler/tree/caewok-libruler for an 
 See https://github.com/caewok/fvtt-speed-ruler for an example of how two modules might interact
 */
 
-import { PathfindingRuler, findPath } from "./main.js";
+import { PathfindingRuler, findPath, MODULE_ID } from "./main.js";
 
-const MODULE_ID = "pathfinding-ruler"
-
-function log(...args) {
-  try {
-      console.log(MODULE_ID, '|', ...args);
-  } catch (e) {}
-}
-
-/*
-Hooks.once('libRulerReady', async function() {
-  log(`libRuler is ready; adding findPath`);
-  Object.defineProperty(Ruler.prototype, "findPath", {
-    value: findPath,
-    writable: true,
-    configurable: true
-  });
-  
-  log(`registering Ruler.measure`);
-  libWrapper.register(MODULE_ID, 'Ruler.prototype.measure', pathfinderMeasure, 'WRAPPER');
-  log(`done registration!`);
-};
-*/
-
-// wrap measure -- whenever measure is called, update the waypoints
-// easier than tracking onMouseMove and should result in less unnecessary processing
 /**
- * Measure the distance between two points and render the ruler UI to illustrate it
+ * Measure the distance between two points and render the ruler UI to illustrate it.
+ * This wrap is to update the waypoints using findPath whenever measure is called.
+ * Easier than tracking onMouseMove and should result in less unnecessary processing.
  * @param {PIXI.Point} destination  The destination point to which to measure
  * @param {boolean} gridSpaces      Restrict measurement only to grid spaces
  */
@@ -45,7 +22,6 @@ export function pathfinderMeasure(wrapped, destination, options) {
   const pathfinding_control = token_controls.tools.find(elem => elem.name === "pathfinding-ruler");
   
   if(pathfinding_control?.active) {
-    log(`measure: pathfinding control is active.`);    
     // this part adapted from main.js mousemoveListener
     const previous_endpoint = this.getFlag(MODULE_ID, "endpoint");
     const newlocation = PathfindingRuler.convertLocationToGridspace(destination);
@@ -55,21 +31,17 @@ export function pathfinderMeasure(wrapped, destination, options) {
       
       // origin for pathfinding is the last user-set waypoint, 
       //   otherwise the origin waypoint
-      log(`${this.waypoints.length} waypoints.`, this.waypoints);
       let idx;
       for(idx = (this.waypoints.length - 1); idx >= 0; idx--) {
         if(!this.waypoints[idx]?.pathfinding) break;
       }
       const origin = this.waypoints[idx];
-      log(`Last user waypoint index is ${idx} at ${origin.x}, ${origin.y}`, this.waypoints);
       const origin_grid = PathfindingRuler.convertLocationToGridspace(origin);
       if(PathfindingRuler.hitsWall(origin_grid, newlocation, true)) {
         // clear back to the last user waypoint
         for(let i = (this.waypoints.length - 1); i > idx; i--) {
-          log(`Removing waypoint ${i}`);
           this._removeWaypoint(destination, {remeasure: false});
         }
-        log(`Finding path from ${origin_grid[0]}, ${origin_grid[1]} to ${newlocation[0]}, ${newlocation[1]}`);
         this.setFlag(MODULE_ID, "pathfinding_active", true); // so addWaypoint can distinguish between user-added waypoints and pathfinding waypoints
         this.findPath(origin_grid, newlocation);
         this.setFlag(MODULE_ID, "pathfinding_active", false);
@@ -81,15 +53,13 @@ export function pathfinderMeasure(wrapped, destination, options) {
 }
 
 /*
- * Wrap _addWaypoint to track when pathfinder adds a waypoint
+ * Wrap _addWaypoint to track when pathfinder (vs a user) adds a waypoint
  */
 export function pathfinderAddWaypoint(wrapped, ...args) {
-  log("Adding waypoint");
   // just capture the new waypoint number after it is added
   wrapped(...args)
   const pathfinding_active = this.getFlag(MODULE_ID, "pathfinding_active");
   if(pathfinding_active) {
-    log(`Marking waypoint ${this.waypoints.length - 1} as pathfinding`);
     this.waypoints[this.waypoints.length - 1].pathfinding = true; 
   }
 }

--- a/scripts/libruler.js
+++ b/scripts/libruler.js
@@ -1,0 +1,54 @@
+/*
+For using Pathfinding Ruler with libRuler
+Whenever the pathfinding tool icon is enabled, any ruler based on libRuler will use
+pathfinding. This means the main Foundry ruler tool, plus any other such as if 
+Drag Ruler were using libRuler.  
+
+See https://github.com/caewok/foundryvtt-drag-ruler/tree/caewok-libruler for an example with Drag Ruler
+See https://github.com/caewok/fvtt-speed-ruler for an example of how two modules might interact
+*/
+
+import { PathfindingRuler, findPath } from "./main.js";
+
+const MODULE_ID = "pathfinding-ruler"
+
+
+
+Hooks.once('libRulerReady', async function() {
+  Object.defineProperty(Ruler.prototype, "findPath", {
+    value: findPath,
+    writable: true,
+    configurable: true
+  });
+  
+  libWrapper.register(MODULE_ID, 'Ruler.prototype.measure', pathfinderMeasure, 'WRAPPER');
+}
+
+// wrap measure -- whenever measure is called, update the waypoints
+// easier than tracking onMouseMove and should result in less unnecessary processing
+/**
+ * Measure the distance between two points and render the ruler UI to illustrate it
+ * @param {PIXI.Point} destination  The destination point to which to measure
+ * @param {boolean} gridSpaces      Restrict measurement only to grid spaces
+ */
+function pathfinderMeasure(wrapped, destination, options) {
+  if(game.activeTool === "pathfinding-ruler") {
+  
+    // this part adapted from main.js mousemoveListener
+    const previous_endpoint = this.getFlag(MODULE_ID, "endpoint");
+    const newlocation = PathfindingRuler.convertLocationToGridspace(destination);
+    if(!previous_endpoint || previous_endpoint[0] !== newlocation[0] || previous_endpoint[1] !== newlocation[1]) {
+      // we have moved destination to another gridspace. 
+      this.setFlag(MODULE_ID, "endpoint", newlocation);
+    
+      const origin_grid = PathfindingRuler.convertLocationToGridSpace(this.origin);
+      if(PathfindingRuler.hitsWall(origin_grid, newlocation, true)) {
+        this.findPath(origin_grid, newlocation);
+      }
+    } 
+  }
+
+  wrapped(destination, options);
+}
+
+

--- a/scripts/libruler.js
+++ b/scripts/libruler.js
@@ -69,7 +69,7 @@ export function pathfinderAddWaypoint(wrapped, ...args) {
  */
 export function pathfinderClear(wrapped) {
   this.unsetFlag(MODULE_ID, "pathfinding_active");
-
+  this.unsetFlag(MODULE_ID, "endpoint");
   wrapped();
 }
  

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -89,6 +89,12 @@ static setSceneControlHooks() {
 						visible: true
 					};
 				}
+				
+				if(game.modules.get('libruler')?.active) {
+				  tool.toggle = true;
+				  tool.active = false; // start inactive after loading game
+				}
+				
 				tokenButton.tools.push(tool);
 			}
 		}); 

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -14,7 +14,7 @@
  */
 "use strict"
 
-import { pathfinderMeasure } from "./libruler.js";
+import { pathfinderMeasure, pathfinderAddWaypoint, pathfinderClear } from "./libruler.js";
 
 const MODULE_ID = "pathfinding-ruler";
 
@@ -35,6 +35,9 @@ Hooks.once('libRulerReady', async function() {
   
   log(`registering Ruler.measure`);
   libWrapper.register(MODULE_ID, 'Ruler.prototype.measure', pathfinderMeasure, 'WRAPPER');
+  libWrapper.register(MODULE_ID, 'Ruler.prototype._addWaypoint', pathfinderAddWaypoint, 'WRAPPER');
+  libWrapper.register(MODULE_ID, 'Ruler.prototype.clear', pathfinderClear, 'WRAPPER');
+  
   log(`done registration!`);
 });
 
@@ -376,11 +379,11 @@ export function findPath(origin, endpoint)
 				
 				if(!use_libruler) this.waypoints = []; // will clear the waypoints in Ruler.measure wrap (see libruler.js)
 				const origin_loc = PathfindingRuler.convertGridspaceToLocation(origin);
-				ret.push(origin_loc);
+				if(!use_libruler) ret.push(origin_loc);
 				PathfindingRuler.pruneWaypoints(ret);
 				for (let i=ret.length-1;i>0;i--) {
 				  if(use_libruler) {
-				    this.addWaypoint(ret[i]);
+				    this._addWaypoint(ret[i]);
 				  } else {
 				    this.waypoints.push(new PIXI.Point(ret[i].x,ret[i].y));
 				  }

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -341,7 +341,7 @@ Hooks.on("init", () => {
 export function findPath(origin, endpoint)
 	{
                 log(`findPath origin ${origin[0]}, ${origin[1]}; destination ${endpoint[0]}, ${endpoint[1]}`, this);
-
+    const use_libruler = game.modules.get('libruler')?.active;
 		const grid = PathfindingRuler.rebuildGrid();
 		endpoint = {x:endpoint[0],y:endpoint[1]};
 		let openList = [];
@@ -358,12 +358,12 @@ export function findPath(origin, endpoint)
 			let currentNode = openList[lowIndex];
 			if (currentNode.f > game.settings.get("pathfinding-ruler", "MaxDistance"))
 			{
-				if(!game.modules.get('libruler')?.active) this.removeRuler();
+				if(!use_libruler) this.removeRuler();
 				return;
 			}
 			if (currentNode.x=== endpoint.x && currentNode.y === endpoint.y)
 			{
-				if(!game.modules.get('libruler')?.active) this.removeRuler();
+				if(!use_libruler) this.removeRuler();
 				let current = currentNode;
 				let ret = [];
 				while(current.parent)
@@ -373,13 +373,19 @@ export function findPath(origin, endpoint)
 					ret.push(loc);
 					current = current.parent;
 				}
-				this.waypoints = [];
+				
+				if(!use_libruler) this.waypoints = []; // will clear the waypoints in Ruler.measure wrap (see libruler.js)
 				const origin_loc = PathfindingRuler.convertGridspaceToLocation(origin);
 				ret.push(origin_loc);
 				PathfindingRuler.pruneWaypoints(ret);
-				for (let i=ret.length-1;i>0;i--)
-					this.waypoints.push(new PIXI.Point(ret[i].x,ret[i].y));
-				if(!game.modules.get('libruler')?.active) this.drawRuler();
+				for (let i=ret.length-1;i>0;i--) {
+				  if(use_libruler) {
+				    this.addWaypoint(ret[i]);
+				  } else {
+				    this.waypoints.push(new PIXI.Point(ret[i].x,ret[i].y));
+				  }
+				}
+				if(!use_libruler) this.drawRuler();
 				return;
 			}
 			openList.splice(lowIndex,1);
@@ -416,7 +422,7 @@ export function findPath(origin, endpoint)
 				}
 			}
 		}
-		if(!game.modules.get('libruler')?.active) this.removeRuler();
+		if(!use_libruler) this.removeRuler();
 	}
 	
 Object.defineProperty(PathfindingRuler.prototype, "findPath", {

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -16,29 +16,19 @@
 
 import { pathfinderMeasure, pathfinderAddWaypoint, pathfinderClear } from "./libruler.js";
 
-const MODULE_ID = "pathfinding-ruler";
-
-function log(...args) {
-  try {
-      console.log(MODULE_ID, '|', ...args);
-  } catch (e) {}
-}
+export const MODULE_ID = "pathfinding-ruler";
 
 
 Hooks.once('libRulerReady', async function() {
-  log(`libRuler is ready; adding findPath`);
   Object.defineProperty(Ruler.prototype, "findPath", {
     value: findPath,
     writable: true,
     configurable: true
   });
   
-  log(`registering Ruler.measure`);
   libWrapper.register(MODULE_ID, 'Ruler.prototype.measure', pathfinderMeasure, 'WRAPPER');
   libWrapper.register(MODULE_ID, 'Ruler.prototype._addWaypoint', pathfinderAddWaypoint, 'WRAPPER');
-  libWrapper.register(MODULE_ID, 'Ruler.prototype.clear', pathfinderClear, 'WRAPPER');
-  
-  log(`done registration!`);
+  libWrapper.register(MODULE_ID, 'Ruler.prototype.clear', pathfinderClear, 'WRAPPER');  
 });
 
 class Config
@@ -142,7 +132,6 @@ setCanvasHooks() {
 			let newlocation = PathfindingRuler.convertLocationToGridspace(event.data.getLocalPosition(canvas.grid));
 			if (this.endpoint[0] !== newlocation[0] || this.endpoint[1] !== newlocation[1])
 			{
-//log(`mousemove newlocation ${newlocation[0]}, ${newlocation[1]}`, this);
 				this.endpoint = newlocation;
 				let token = canvas.tokens.controlled[0];
 				if (token)
@@ -343,7 +332,6 @@ Hooks.on("init", () => {
 
 export function findPath(origin, endpoint)
 	{
-                log(`findPath origin ${origin[0]}, ${origin[1]}; destination ${endpoint[0]}, ${endpoint[1]}`, this);
     const use_libruler = game.modules.get('libruler')?.active;
 		const grid = PathfindingRuler.rebuildGrid();
 		endpoint = {x:endpoint[0],y:endpoint[1]};

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -6,11 +6,11 @@
  *
  *	This program is distributed in the hope that it will be useful,
  *	but WITHOUT ANY WARRANTY; without even the implied warranty of
- *	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
+ *	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *	GNU General Public License for more details.
  *
  *	You should have received a copy of the GNU General Public License
- *	along with this program.	If not, see <https://www.gnu.org/licenses/>.
+ *	along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 "use strict"
 
@@ -114,7 +114,7 @@ static setSceneControlHooks() {
 				
 				tokenButton.tools.push(tool);
 			}
-		}); 
+		});
 }
 
 setCanvasHooks() {
@@ -123,7 +123,7 @@ setCanvasHooks() {
 			this.ruler = canvas.controls._rulers[game.user._id];
 		});
 	}
-
+	
 	
 	mousemoveListener(event)
 	{

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -48,7 +48,7 @@ class Config
 	}
 }
 
-class PathfindingRuler
+export class PathfindingRuler
 {
 	constructor()
 	{

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -239,7 +239,75 @@ setCanvasHooks() {
 		return grid;
 	}
 	
-  findPath(origin, endpoint)
+	static isInList(list, node)
+	{
+		for (let i=0; i<list.length; i++)
+		{
+			if (list[i].x === node.x && list[i].y === node.y)
+				return true;
+		}
+		return false;
+	}
+	
+	static isValidNode(node)
+	{
+		return (node.y >= 0 && node.y < (canvas.grid._height/canvas.grid.size) && node.x >= 0 && node.x < (canvas.grid._width/canvas.grid.size));
+	}
+	
+	static getNeighbors(node, grid)
+	{
+		let neighbors = [];
+		let x = node.x;
+		let y = node.y;
+		for (let i=-1; i<2; i++)
+		{
+			for (let j=-1;j<2;j++)
+			{
+				if (!(i===0 && j===0)&&PathfindingRuler.isValidNode({x:x+i,y:y+j}))
+					neighbors.push(grid[x+i][y+j]);
+			}
+		}
+		return neighbors;
+	}
+	
+	heuristic(start,end)
+	{
+		let xdistance = Math.abs(start.x-end.x);
+		let ydistance = Math.abs(start.y-end.y);
+		if (xdistance>ydistance) return (xdistance+(ydistance/2));
+		else return (ydistance+(xdistance/2));
+	}
+	
+	static pruneWaypoints(waypointlist)
+	{
+		let i=0;
+		while(i<waypointlist.length-2)
+		{
+			if (!PathfindingRuler.hitsWall(waypointlist[i],waypointlist[i+2],false))
+			{
+				waypointlist.splice(i+1,1);
+			}
+			else
+			{
+				i++;
+			}
+		}
+	}
+}
+
+
+Hooks.on("init", () => {
+	if(!game.modules.get('libruler')?.active) {
+		const pathfindingRuler = new PathfindingRuler();
+	} else {
+		 // we need to instantiate the config settings b/c we are not creating the full Pathfinder Class from main.js
+		new Config();
+		PathfindingRuler.setSceneControlHooks();
+	}
+});
+
+
+export function findPath(origin, endpoint)
 	{
 		const grid = PathfindingRuler.rebuildGrid();
 		endpoint = {x:endpoint[0],y:endpoint[1]};
@@ -317,76 +385,6 @@ setCanvasHooks() {
 		}
 		if(!game.modules.get('libruler')?.active) this.removeRuler();
 	}
-	
-	static isInList(list, node)
-	{
-		for (let i=0; i<list.length; i++)
-		{
-			if (list[i].x === node.x && list[i].y === node.y)
-				return true;
-		}
-		return false;
-	}
-	
-	static isValidNode(node)
-	{
-		return (node.y >= 0 && node.y < (canvas.grid._height/canvas.grid.size) && node.x >= 0 && node.x < (canvas.grid._width/canvas.grid.size));
-	}
-	
-	static getNeighbors(node, grid)
-	{
-		let neighbors = [];
-		let x = node.x;
-		let y = node.y;
-		for (let i=-1; i<2; i++)
-		{
-			for (let j=-1;j<2;j++)
-			{
-				if (!(i===0 && j===0)&&PathfindingRuler.isValidNode({x:x+i,y:y+j}))
-					neighbors.push(grid[x+i][y+j]);
-			}
-		}
-		return neighbors;
-	}
-	
-	heuristic(start,end)
-	{
-		let xdistance = Math.abs(start.x-end.x);
-		let ydistance = Math.abs(start.y-end.y);
-		if (xdistance>ydistance) return (xdistance+(ydistance/2));
-		else return (ydistance+(xdistance/2));
-	}
-	
-	static pruneWaypoints(waypointlist)
-	{
-		let i=0;
-		while(i<waypointlist.length-2)
-		{
-			if (!PathfindingRuler.hitsWall(waypointlist[i],waypointlist[i+2],false))
-			{
-				waypointlist.splice(i+1,1);
-			}
-			else
-			{
-				i++;
-			}
-		}
-	}
-}
-
-
-Hooks.on("init", () => {
-	if(!game.modules.get('libruler')?.active) {
-		const pathfindingRuler = new PathfindingRuler();
-	} else {
-		 // we need to instantiate the config settings b/c we are not creating the full Pathfinder Class from main.js
-		new Config();
-		PathfindingRuler.setSceneControlHooks();
-	}
-});
-
-
-
 	
 Object.defineProperty(PathfindingRuler.prototype, "findPath", {
 	value: findPath,

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -100,7 +100,7 @@ setCanvasHooks() {
 			this.ruler = canvas.controls._rulers[game.user._id];
 		});
 	}
-}
+
 	
 	mousemoveListener(event)
 	{


### PR DESCRIPTION
Hi! This pull request provides compatibility with libRuler and endeavors not to change Pathfinding Ruler's existing functionality when libRuler is not present. 

**Why this PR is useful**
[libRuler](https://github.com/caewok/fvtt-lib-ruler) is my attempt to make a module, based on libWrapper, that permits various modules to override and enhance the Foundry Ruler in a cooperative manner. libRuler overrides Ruler.measure and related methods to provide a more granular means to override Foundry Ruler functionality. The idea is that, for example, one module might add color to identify token movement rates (see [Speed Ruler](https://github.com/caewok/fvtt-speed-ruler)), another might add the ability to change elevation (see [Elevation Ruler](https://github.com/caewok/fvtt-elevation-ruler)) and a third might change how the ruler measures diagonals (see [Manhattan Ruler](https://github.com/caewok/fvtt-manhattan-ruler)). Users can enable one or more of these modules and see increased functionality when using the Foundry Ruler.

With this PR, when libRuler is installed, users can simply toggle the Pathfinding Ruler icon on. When on, the underlying Foundry Ruler control will use pathfinding. They would also get pathfinding when dragging tokens if they used the [branch of Drag Ruler](https://github.com/caewok/foundryvtt-drag-ruler/tree/caewok-libruler) I [recently submitted as a PR](https://github.com/manuelVo/foundryvtt-drag-ruler/pull/108). Which I have to say, adding Pathfinding to Drag Ruler is super-useful! It would also resolve issue #6.

With this PR and libRuler installed, pathfinding will go from the last user-added waypoint (origin if none) to the current destination. Thus, users gain some ability to add or remove waypoints manually as they would expect using the underlying Foundry Ruler.

**What this PR does in code**
First, it switches from script to esmodule in the module.json, so that I could use import/export. This allows me to create a second script, libruler.js, with much of the new code.

Second, as mentioned, it adds libruler.js. This is where I "wrap" three Ruler methods. (See [libWrapper](https://github.com/ruipin/fvtt-lib-wrapper) if you are unfamiliar with the concept, but basically it means the wrapped code is called before the main function.)

1. Wrap `Ruler.prototype.measure`: This is the heart of the change. When `measure` is called and the Pathfinding tool icon is toggled on, this code checks to see if the destination has changed since the last time, and if so, checks for wall collisions. If a collision is found, `findPath` is called to create the new waypoints. This is basically the same functionality as the existing code from the `mousemoveListener` method. The trick is, we use the underling `_removeWaypoint` and `_addWaypoint` instead of just deleting all the waypoints, to improve compatibility with other modules. We also only remove waypoints back to the last user-set waypoint. This allows users to still set waypoints themselves.
2. Wrap `Ruler.prototype._addWaypoint`: Needed just to tell when Pathfinding Ruler is adding the waypoint using `findPath.` Basically, `pathfinderMeasure` sets a flag putting it in "pathfinding" mode, then calls `findPath.` It is assumed that any waypoints added while that mode is active is due to Pathfinding  Ruler finding a new path, and they are marked accordingly.
3. Wrap `Ruler.prototype.clear`: Clear flags we previously set.

Third, the PR modifies main.js, mainly with a bunch of switches if libRuler is active. libRuler needs to call `findPath,` and so to allow for maximum code reuse, I changed a lot of methods to be static. The git diff indicates more changes than I really did, because I had to move out the findPath to be a separate function that could then be added to the PathfindingRuler class or the Ruler class, depending on whether libRuler is present. But really, the changes amount to:

1. Add hook to register methods if libRuler is present. 
2. Switch the control tool to a toggle if libRuler is present.
3. Set various methods as static so they can be called without instantiating the full PathfindingRuler class.
4. Pull out `findPath` as a separate function so it can be used without or without libRuler present. Add it back to the class using `Object.defineProperty.`
5. Add a bunch of checks in `findPath` to change how waypoints are handled and avoid calling various PathfindingRuler methods if libRuler is present.

A lot of this, of course, is to preserve your original functionality in cases when libRuler is not installed. 

**Testing**
I tested in Foundry 0.8.8 and 0.8.9, with and without libRuler. When using libRuler, I also tried it with [Speed Ruler](https://github.com/caewok/fvtt-speed-ruler), [my version of Drag Ruler](https://github.com/caewok/foundryvtt-drag-ruler/tree/caewok-libruler), and [Elevation Ruler](https://github.com/caewok/fvtt-elevation-ruler). 

Note that I pushed a new version of libRuler (0.1.5) to handle removing waypoints without immediately re-measuring, something this PR relies on.
